### PR TITLE
Fix docs generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ npm-debug.log
 ntask.sqlite
 ntask_test.sqlite
 .DS_Store
-public/apidoc
+public/docs
 logs/*.log

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "npm run apidoc && npm run clusters",
     "clusters": "babel-node clusters.js",
     "test": "NODE_ENV=test mocha test/**/*.js",
-    "apidoc": "apidoc -i routes -o public/apidoc"
+    "apidoc": "apidoc -i routes/ -o public/docs"
   },
   "apidoc": {
     "name": "Node Task - Documentação de API",


### PR DESCRIPTION
The current `apidoc` command is not generating the docs at all because was missing a `/` in the `routes` path.

I also changed the `apidoc` folder because it was not generating with this name (I don't know why), so I changed to `docs`.
